### PR TITLE
Allow fqsen with utf-8 chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # ReflectionCommon
+[![Build Status](https://travis-ci.org/phpDocumentor/ReflectionCommon.svg?branch=master)](https://travis-ci.org/phpDocumentor/ReflectionCommon)

--- a/src/Fqsen.php
+++ b/src/Fqsen.php
@@ -38,7 +38,11 @@ final class Fqsen
     public function __construct($fqsen)
     {
         $matches = array();
-        $result = preg_match('/^\\\\([\\w_\\\\]*)(?:[:]{2}\\$?([\\w_]+))?(?:\\(\\))?$/', $fqsen, $matches);
+        $result = preg_match(
+            '/^\\\\([a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff\\\\]*)?(?:[:]{2}\\$?([a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*))?(?:\\(\\))?$/',
+                $fqsen,
+                $matches
+        );
 
         if ($result === 0) {
             throw new \InvalidArgumentException(

--- a/tests/unit/FqsenTest.php
+++ b/tests/unit/FqsenTest.php
@@ -43,6 +43,7 @@ class FqsenTest extends \PHPUnit_Framework_TestCase
             ['\My\Space\MY_CONSTANT2', 'MY_CONSTANT2'],
             ['\My\Space\MyClass', 'MyClass'],
             ['\My\Space\MyInterface', 'MyInterface'],
+            ['\My\Space\Option«T»', 'Option«T»'],
             ['\My\Space\MyTrait', 'MyTrait'],
             ['\My\Space\MyClass::myMethod()', 'myMethod'],
             ['\My\Space\MyClass::$my_property', 'my_property'],
@@ -72,6 +73,7 @@ class FqsenTest extends \PHPUnit_Framework_TestCase
             ['\My\*'],
             ['\My\Space\.()'],
             ['My\Space'],
+            ['1_function()']
         ];
     }
 


### PR DESCRIPTION
Be more specific when checking the first character of the element names.
And allow utf-8 chars in element names according to the php spec.

Fixes #7.