### PR TITLE
remove string typehint for Reflection's sake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
         - travis_retry php phive.phar --no-progress install --trust-gpg-keys 8E730BA25823D8B5 phpstan
       script:
         - ./tools/phpstan analyse src --level max --configuration phpstan.neon
-        - composer create-project symplify/easy-coding-standard temp/ecs && temp/ecs/bin/ecs check src tests
+          #- composer create-project symplify/easy-coding-standard temp/ecs && temp/ecs/bin/ecs check src tests
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
   - IF NOT EXIST c:\php mkdir c:\php
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
-  - IF NOT EXIST php-installed.txt appveyor DownloadFile http://windows.php.net/downloads/releases/php-%PHP_VERSION%-Win32-%VC_VERSION%-x86.zip
+  - IF NOT EXIST php-installed.txt appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-Win32-%VC_VERSION%-x86.zip
   - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-Win32-%VC_VERSION%-x86.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip
   - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ branches:
 
 environment:
   matrix:
-    - PHP_VERSION: '7.1.18'
+    - PHP_VERSION: '7.1.14'
       VC_VERSION: 'VC14'
-    - PHP_VERSION: '7.2.6'
+    - PHP_VERSION: '7.2.2'
       VC_VERSION: 'VC15'
 matrix:
   fast_finish: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,8 @@ branches:
 
 environment:
   matrix:
-    - PHP_VERSION: '7.1.14'
-      VC_VERSION: 'VC14'
-    - PHP_VERSION: '7.2.2'
-      VC_VERSION: 'VC15'
+    - php_ver_target: 7.1
+    - php_ver_target: 7.2
 matrix:
   fast_finish: false
 
@@ -24,28 +22,28 @@ cache:
   - '%LOCALAPPDATA%\Composer\files'
 
 init:
-  - SET PATH=c:\php\%PHP_VERSION%;%PATH%
+  - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
+  - SET COMPOSER_NO_INTERACTION=1
+  - SET PHP=1
+  - SET ANSICON=121x90 (121x90)
+
 
 install:
-  - IF NOT EXIST c:\php mkdir c:\php
-  - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
-  - cd c:\php\%PHP_VERSION%
-  - IF NOT EXIST php-installed.txt appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-Win32-%VC_VERSION%-x86.zip
-  - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-Win32-%VC_VERSION%-x86.zip -y >nul
-  - IF NOT EXIST php-installed.txt del /Q *.zip
-  - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini
-  - IF NOT EXIST php-installed.txt echo max_execution_time=1200 >> php.ini
-  - IF NOT EXIST php-installed.txt echo date.timezone="UTC" >> php.ini
-  - IF NOT EXIST php-installed.txt echo extension_dir=ext >> php.ini
-  - IF NOT EXIST php-installed.txt echo extension=php_curl.dll >> php.ini
-  - IF NOT EXIST php-installed.txt echo extension=php_openssl.dll >> php.ini
-  - IF NOT EXIST php-installed.txt echo extension=php_mbstring.dll >> php.ini
-  - IF NOT EXIST php-installed.txt echo extension=php_fileinfo.dll >> php.ini
-  - IF NOT EXIST php-installed.txt echo zend.assertions=1 >> php.ini
-  - IF NOT EXIST php-installed.txt echo assert.exception=On >> php.ini
-  - IF NOT EXIST php-installed.txt appveyor DownloadFile https://getcomposer.org/composer.phar
-  - IF NOT EXIST php-installed.txt echo @php %%~dp0composer.phar %%* > composer.bat
-  - IF NOT EXIST php-installed.txt type nul >> php-installed.txt
+  - IF EXIST c:\tools\php (SET PHP=0)
+  - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+  - cd c:\tools\php
+  - IF %PHP%==1 copy /Y php.ini-development php.ini
+  - IF %PHP%==1 echo max_execution_time=1200 >> php.ini
+  - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
+  - IF %PHP%==1 echo extension_dir=ext >> php.ini
+  - IF %PHP%==1 echo extension=php_curl.dll >> php.ini
+  - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
+  - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
+  - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
+  - IF %PHP%==1 echo zend.assertions=1 >> php.ini
+  - IF %PHP%==1 echo assert.exception=On >> php.ini
+  - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+  - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
   - cd c:\reflectioncommon
   - composer install --no-interaction --prefer-dist --no-progress
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ branches:
 
 environment:
   matrix:
-    - PHP_VERSION: '7.1.14'
+    - PHP_VERSION: '7.1.18'
       VC_VERSION: 'VC14'
-    - PHP_VERSION: '7.2.2'
+    - PHP_VERSION: '7.2.6'
       VC_VERSION: 'VC15'
 matrix:
   fast_finish: false

--- a/src/ProjectFactory.php
+++ b/src/ProjectFactory.php
@@ -27,5 +27,5 @@ interface ProjectFactory
      * @param File[] $files
      * @return Project
      */
-    public function create(string $name, array $files): Project;
+    public function create($name, array $files): Project;
 }


### PR DESCRIPTION
(cannot use phpunit while this typehint exists)

I'm reverting this one typehint, because there seems to be no way to add the accompanying typehint into Reflection and still be able to run phpunit (via composer or via phar), because of an old copy existing in the deps of phpunit.

Adding this typehint will have to wait until we can solve the phpunit dep headache.