### PR TITLE
Don't throw InvalidArgumentException if passed an anonymous class

### DIFF
--- a/src/Fqsen.php
+++ b/src/Fqsen.php
@@ -48,9 +48,13 @@ final class Fqsen
         );
 
         if ($result === 0) {
-            throw new InvalidArgumentException(
-                sprintf('"%s" is not a valid Fqsen.', $fqsen)
-            );
+            if(strpos($fqsen, "class@anonymous") === 0) {
+                $matches=[null,null,$fqsen];
+            } else {
+                throw new InvalidArgumentException(
+                    sprintf('"%s" is not a valid Fqsen.', $fqsen)
+                );
+            }
         }
 
         $this->fqsen = $fqsen;


### PR DESCRIPTION
Partial fix for phpDocumentor/ReflectionDocBlock#180