### PR TITLE
.gitignore: ignore PHPUnit cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vendor/
 
 # By default the phpunit.xml.dist is provided; you can override this using a local config file
 phpunit.xml
+.phpunit.result.cache


### PR DESCRIPTION
Since PHPUnit 8.x, PHPUnit generates a cache file. This file should not be committed to the repository.