### PR TITLE
Phive: upgrade to use latest version of Phive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: install-phive
 install-phive:
 	mkdir tools; \
-	wget -O tools/phive.phar https://github.com/phar-io/phive/releases/download/0.13.2/phive-0.13.2.phar; \
-	wget -O tools/phive.phar.asc https://github.com/phar-io/phive/releases/download/0.13.2/phive-0.13.2.phar.asc; \
+	wget -O tools/phive.phar https://phar.io/releases/phive.phar; \
+	wget -O tools/phive.phar.asc https://phar.io/releases/phive.phar.asc; \
 	gpg --keyserver pool.sks-keyservers.net --recv-keys 0x9D8A98B29B2D5D79; \
 	gpg --verify tools/phive.phar.asc tools/phive.phar; \
 	chmod +x tools/phive.phar


### PR DESCRIPTION
The version previously used was not compatible with Xdebug 3.x, nor with PHP 8.1.

The current latest release - 0.15.0 - has a minimum PHP requirement of PHP 7.3, which matches this project's requirements, so should be safe to use.

If at some point in the future, the minimum PHP requirements would no longer match, the Phive version can be fixed to a specific release again.

Ref: https://github.com/phar-io/phive/releases