### PR TITLE
Tests: add missing `@covers` tag

### DIFF
--- a/tests/unit/FqsenTest.php
+++ b/tests/unit/FqsenTest.php
@@ -23,6 +23,7 @@ class FqsenTest extends TestCase
 {
     /**
      * @covers ::__construct
+     * @covers ::getName
      * @dataProvider validFqsenProvider
      */
     public function testValidFormats(string $fqsen, string $name) : void


### PR DESCRIPTION
The `Fqsen:getName()` method - while not containing any real logic - is used in and therefore tested by the `FqsenTest::testValidFormats()` test.