### PR TITLE
Psalm: switch from Phive to Composer

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -182,7 +182,6 @@ jobs:
         with:
           php-version: 7.3
           ini-values: memory_limit=2G, display_errors=On, error_reporting=-1
-          tools: psalm
           coverage: none
 
       - name: Get composer cache directory
@@ -201,7 +200,7 @@ jobs:
           composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
 
       - name: Psalm
-        run: psalm --output-format=github
+        run: vendor/bin/psalm.phar --output-format=github
 
   bc_check:
     name: BC Check

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ phpstan:
 
 .PHONY: psalm
 psalm:
-	docker run -it --rm -v${PWD}:/opt/project -w /opt/project php:7.2 tools/psalm --show-info=true
+	docker run -it --rm -v${PWD}:/opt/project -w /opt/project php:7.3 vendor/bin/psalm.phar
 .PHONY: test
 test:
 	docker run -it --rm -v${PWD}:/opt/project -w /opt/project php:7.2 tools/phpunit

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
         "phpDocumentor\\Reflection\\": "src/"
       }
     },
-    "require-dev": {},
+    "require-dev": {
+        "psalm/phar": "^4.8"
+    },
     "extra": {
         "branch-alias": {
             "dev-2.x": "2.x-dev"

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,45 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb595626cd86acfd0900ce858f564a44",
+    "content-hash": "804715166512d595cbaaf15d2e691dd2",
     "packages": [],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "psalm/phar",
+            "version": "4.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/phar.git",
+                "reference": "ce0856e5c28a78382d1fa4e1a11cf9aac6292231"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/phar/zipball/ce0856e5c28a78382d1fa4e1a11cf9aac6292231",
+                "reference": "ce0856e5c28a78382d1fa4e1a11cf9aac6292231",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "vimeo/psalm": "*"
+            },
+            "bin": [
+                "psalm.phar"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer-based Psalm Phar",
+            "support": {
+                "issues": "https://github.com/psalm/phar/issues",
+                "source": "https://github.com/psalm/phar/tree/4.8.1"
+            },
+            "time": "2021-06-21T02:02:58+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
@@ -15,5 +51,6 @@
     "platform": {
         "php": "^7.3 || ^8.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
 }

--- a/phive.xml
+++ b/phive.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <phar name="phpunit" version="^9.4.0" installed="9.4.0" location="./tools/phpunit" copy="false"/>
-  <phar name="psalm" version="^3.7.2" installed="3.11.2" location="./tools/psalm" copy="true"/>
 </phive>

--- a/src/Fqsen.php
+++ b/src/Fqsen.php
@@ -61,9 +61,11 @@ final class Fqsen
 
         if (isset($matches[2])) {
             $this->name = $matches[2];
+        } elseif ($fqsen === '\\') {
+            $this->name = '';
         } else {
             $matches = explode('\\', $fqsen);
-            $name = (string) end($matches);
+            $name = end($matches);
             $this->name = trim($name, '()');
         }
     }


### PR DESCRIPTION
### Psalm: switch from Phive to Composer

This switches the installation method for Psalm from Phive to Composer, while still using a Phar file for running Psalm.

Includes:
* Removing Psalm from the Phive configuration.
* Adding Psalm to the Composer configuration. Includes upgrading from version `3.11.2` to version `4.8.1`.
* Adjusting the script used in the `Makefile`.
    👉 Please verify and test this as things work differently on different OS-es and this should work for you.
* Adjusting the GH Actions script to use the Composer installed version of Psalm.

Note: due to the committed `composer.lock` file, Psalm will not automatically upgrade when newer versions are available.

Refs:
* https://github.com/vimeo/psalm/releases
* https://github.com/psalm/phar/releases

### Defensive coding fix

The `$matches` array returned by `explode()` can be an empty array. In that case, `end()` would return `false`, which due to the string cast would become an empty string.

Psalm flags the string cast though with:
```
ERROR: RedundantCast - src/Fqsen.php:66:21 - Redundant cast to string (see https://psalm.dev/262)
            $name = (string) end($matches);
```
... which in my opinion is incorrect.

I tried various options to get round this, but most ended up being flagged by Psalm again, even though IMO this flagging is incorrect.

Either way, the current change fixes the Psalm violation and does not trigger new violation flags.

