### PR TITLE
GH Actions: start testing against PHP 8.1

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -83,7 +83,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-latest
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     name: Unit tests for PHP version ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
     needs:
       - setup


### PR DESCRIPTION
While PHP 8.1 has not been released yet, it is common to allow such a build to fail.

However, as the tests currently pass (after all the other PRs have now been merged), I see no reason to do so. If they pass now, let's make sure it stays that way.

Fixes #37 (in combination with the previous PRs)