### PR TITLE
CS update after upstream changes

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,11 +1,17 @@
 <?xml version="1.0"?>
-<ruleset name="phpDocumentor">
- <description>The coding standard for phpDocumentor.</description>
+<ruleset name="ReflectionCommon">
+ <description>The coding standard for this library.</description>
 
     <file>src</file>
     <file>tests/unit</file>
     <arg value="p"/>
 
+    <!-- Set the minimum PHP version for PHPCompatibility.
+         This should be kept in sync with the requirements in the composer.json file. -->
+    <config name="testVersion" value="7.3-"/>
+
     <rule ref="phpDocumentor">
+        <!-- Property type declarations are a PHP 7.4 feature. -->
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
     </rule>
 </ruleset>

--- a/src/Element.php
+++ b/src/Element.php
@@ -21,10 +21,10 @@ interface Element
     /**
      * Returns the Fqsen of the element.
      */
-    public function getFqsen() : Fqsen;
+    public function getFqsen(): Fqsen;
 
     /**
      * Returns the name of the element.
      */
-    public function getName() : string;
+    public function getName(): string;
 }

--- a/src/File.php
+++ b/src/File.php
@@ -21,15 +21,15 @@ interface File
     /**
      * Returns the content of the file as a string.
      */
-    public function getContents() : string;
+    public function getContents(): string;
 
     /**
      * Returns md5 hash of the file.
      */
-    public function md5() : string;
+    public function md5(): string;
 
     /**
      * Returns an relative path to the file.
      */
-    public function path() : string;
+    public function path(): string;
 }

--- a/src/Fqsen.php
+++ b/src/Fqsen.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection;
 
 use InvalidArgumentException;
+
 use function end;
 use function explode;
 use function preg_match;
@@ -73,7 +74,7 @@ final class Fqsen
     /**
      * converts this class to string.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->fqsen;
     }
@@ -81,7 +82,7 @@ final class Fqsen
     /**
      * Returns the name of the element without path.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Location.php
+++ b/src/Location.php
@@ -38,7 +38,7 @@ final class Location
     /**
      * Returns the line number that is covered by this location.
      */
-    public function getLineNumber() : int
+    public function getLineNumber(): int
     {
         return $this->lineNumber;
     }
@@ -46,7 +46,7 @@ final class Location
     /**
      * Returns the column number (character position on a line) for this location object.
      */
-    public function getColumnNumber() : int
+    public function getColumnNumber(): int
     {
         return $this->columnNumber;
     }

--- a/src/Project.php
+++ b/src/Project.php
@@ -21,5 +21,5 @@ interface Project
     /**
      * Returns the name of the project.
      */
-    public function getName() : string;
+    public function getName(): string;
 }

--- a/src/ProjectFactory.php
+++ b/src/ProjectFactory.php
@@ -24,5 +24,5 @@ interface ProjectFactory
      *
      * @param File[] $files
      */
-    public function create(string $name, array $files) : Project;
+    public function create(string $name, array $files): Project;
 }

--- a/tests/unit/FqsenTest.php
+++ b/tests/unit/FqsenTest.php
@@ -26,7 +26,7 @@ class FqsenTest extends TestCase
      * @covers ::getName
      * @dataProvider validFqsenProvider
      */
-    public function testValidFormats(string $fqsen, string $name) : void
+    public function testValidFormats(string $fqsen, string $name): void
     {
         $instance = new Fqsen($fqsen);
         $this->assertEquals($name, $instance->getName());
@@ -37,7 +37,7 @@ class FqsenTest extends TestCase
      *
      * @return array<array<string>>
      */
-    public function validFqsenProvider() : array
+    public function validFqsenProvider(): array
     {
         return [
             ['\\', ''],
@@ -59,7 +59,7 @@ class FqsenTest extends TestCase
      * @covers ::__construct
      * @dataProvider invalidFqsenProvider
      */
-    public function testInValidFormats(string $fqsen) : void
+    public function testInValidFormats(string $fqsen): void
     {
         $this->expectException(InvalidArgumentException::class);
         new Fqsen($fqsen);
@@ -70,7 +70,7 @@ class FqsenTest extends TestCase
      *
      * @return array<array<string>>
      */
-    public function invalidFqsenProvider() : array
+    public function invalidFqsenProvider(): array
     {
         return [
             ['\My\*'],
@@ -84,7 +84,7 @@ class FqsenTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testToString() : void
+    public function testToString(): void
     {
         $className = new Fqsen('\\phpDocumentor\\Application');
 


### PR DESCRIPTION
### PHPCS ruleset: update ruleset for upstream changes

* Fix the name and description to prevent confusion between the project ruleset and the organisation ruleset.
* Set the minimum PHP version for the PHPCompatibility standard.
* Don't require property type declarations.

### CS: various fixes 