### PR TITLE
GH Actions: version update for various predefined actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Restore/cache vendor folder
         uses: actions/cache@v1
@@ -48,7 +48,7 @@ jobs:
     name: Unit tests
     needs: setup
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -89,7 +89,7 @@ jobs:
       - setup
       - phpunit-with-coverage
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Restore/cache tools folder
         uses: actions/cache@v1
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, phpunit]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Restore/cache vendor folder
         uses: actions/cache@v1
         with:
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, phpunit]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Restore/cache vendor folder
         uses: actions/cache@v1
         with:
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, phpunit]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, phpunit]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: fetch tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Restore/cache vendor folder


### PR DESCRIPTION
A number of predefined actions have had major release, which warrant an update to the workflow(s).

These updates don't actually contain any changed functionality, they are mostly just a change of the Node version used by the action itself (from Node 14 to Node 16).

Refs:
* https://github.com/actions/checkout/releases